### PR TITLE
Add missing ansible.netcommon dependency

### DIFF
--- a/galaxy.yml
+++ b/galaxy.yml
@@ -45,7 +45,8 @@ tags:
 # collection label 'namespace.name'. The value is a version range
 # L(specifiers,https://python-semanticversion.readthedocs.io/en/latest/#requirement-specification). Multiple version
 # range specifiers can be set and are separated by ','
-#dependencies: {}
+dependencies:
+  ansible.netcommon: '>=2.0.0'
 
 # The URL of the originating SCM repository
 repository: https://github.com/ansible-collections/trendmicro.deepsec


### PR DESCRIPTION
##### SUMMARY

Add missing `ansible.netcommon` dependency.

##### ISSUE TYPE

- Bugfix Pull Request

##### COMPONENT NAME
whole collection

##### Additiona notes

I noticed missing dependency during the Ansible Contributor Summit session when I was explaining that for sanity tests, we need to manually install dependencies, but they will be correctly installed for end users. But when I opened the `galaxy.yml` file, the dependencies were commented out.

This PR adds the missing `ansible.netcommon` dependency. I assumed the collection needs 2.0.0 or newer, but feel free to correct me if I am wrong.