### PR TITLE
To fix Deepsec log inspection rule idempotent bug

### DIFF
--- a/changelogs/fragments/log_inspection_rule_log_file_param_issue.yaml
+++ b/changelogs/fragments/log_inspection_rule_log_file_param_issue.yaml
@@ -1,0 +1,3 @@
+---
+bugfixes:
+- To fix the Log inspection rules module bug, where log_files param was not parsed as expected in idempotent play output.

--- a/plugins/action/deepsec_log_inspection_rules.py
+++ b/plugins/action/deepsec_log_inspection_rules.py
@@ -341,6 +341,9 @@ class ActionModule(ActionBase):
                         if every.get("logFiles"):
                             every["log_files"] = self.log_files_fn(every)
                             every.pop("logFiles")
+                        every = self.convert_dict_to_list(
+                            every, "log_files", "log_files"
+                        )
                         before.append(every)
                         after.append(every)
                         temp_name.append(every["name"])
@@ -348,6 +351,9 @@ class ActionModule(ActionBase):
                     if every.get("logFiles"):
                         every["log_files"] = self.log_files_fn(every)
                         every.pop("logFiles")
+                    every = self.convert_dict_to_list(
+                        every, "log_files", "log_files"
+                    )
                     before.append(every)
                     after.append(every)
             else:

--- a/tests/integration/targets/deepsec_log_inspection_rules/tests/cli/replaced.yaml
+++ b/tests/integration/targets/deepsec_log_inspection_rules/tests/cli/replaced.yaml
@@ -31,23 +31,47 @@
                 - location: /var/log/messages
                   format: syslog
 
-    - assert:
+    - name: To remove ID from the before dict
+      set_fact:
+        before: "{{ before | default([]) | combine({ item.key : item.value }) }}"
+      when: "{{item.key not in ['id']}}"
+      with_dict: "{{ dict }}"
+      loop: "{{ result['log_inspection_rules']['before'] }}"
+
+    - name: To remove ID from the after dict
+      set_fact:
+        after: "{{ after | default([]) | combine({ item.key : item.value }) }}"
+      when: "{{item.key not in ['id']}}"
+      with_dict: "{{ dict }}"
+      loop: "{{ result['log_inspection_rules']['after'] }}"
+
+    - name: Assert that task was completed and generated before and after as expected
+      assert:
         that:
           - result.changed == true
-          - "{{ replaced['before'] | symmetric_difference(result['log_inspection_rules']['before']) |\
-            \ length == 2 }}"
-          - "{{ replaced['after'] | symmetric_difference(result['log_inspection_rules']['after']) |\
-            \ length == 2 }}"
+          - "{{ replaced['before'] | symmetric_difference([before]) |\
+            \ length == 0 }}"
+          - "{{ replaced['after'] | symmetric_difference([after]) |\
+            \ length == 0 }}"
 
     - name: Replaces device configuration of Log Inspection Rule with provided configuration
         (IDEMPOTENT)
       register: result
       trendmicro.deepsec.deepsec_log_inspection_rules: *id001
 
-    - name: Assert that task was idempotent
+    - name: To remove ID from the before dict
+      set_fact:
+        before: "{{ before | default([]) | combine({ item.key : item.value }) }}"
+      when: "{{item.key not in ['id']}}"
+      with_dict: "{{ dict }}"
+      loop: "{{ result['log_inspection_rules']['before'] }}"
+
+    - name: Assert that task was idempotent and before is generated as expected
       assert:
         that:
           - result['changed'] == false
+          - "{{ replaced['after'] | symmetric_difference([before]) |\
+            \ length == 0 }}"
 
   always:
 

--- a/tests/integration/targets/deepsec_log_inspection_rules/vars/main.yaml
+++ b/tests/integration/targets/deepsec_log_inspection_rules/vars/main.yaml
@@ -14,8 +14,8 @@ merged:
         log_files:
           - format: mysql-log
             location: /var/log/mysqld.log
-      minimum_agent_version: 6.0.0.0
-      minimum_manager_version: 6.0.0
+      minimum_agent_version: "6.0.0.0"
+      minimum_manager_version: "6.0.0"
       name: "custom log_rule for mysqld event"
       pattern: name
       pattern_type: string
@@ -26,8 +26,7 @@ merged:
     - alert_enabled: true
       alert_minimum_severity: 5
       dependency: none
-      description: false
-      destination_iptype: "log daemon event"
+      description: "log daemon event"
       groups:
         - "test"
       level: 0
@@ -35,8 +34,8 @@ merged:
         log_files:
           - format: syslog
             location: /var/log/daemon.log
-      minimum_agent_version: 6.0.0.0
-      minimum_manager_version: 6.0.0
+      minimum_agent_version: "6.0.0.0"
+      minimum_manager_version: "6.0.0"
       name: "custom log_rule for daemon event"
       pattern: name
       pattern_type: string
@@ -49,9 +48,8 @@ replaced:
   before:
     - alert_enabled: true
       alert_minimum_severity: 5
-      dependency: none
-      description: false
-      destination_iptype: "log daemon event"
+      dependency: "none"
+      description: "log daemon event"
       groups:
         - "test"
       level: 0
@@ -59,8 +57,8 @@ replaced:
         log_files:
           - format: syslog
             location: /var/log/daemon.log
-      minimum_agent_version: 6.0.0.0
-      minimum_manager_version: 6.0.0
+      minimum_agent_version: "6.0.0.0"
+      minimum_manager_version: "6.0.0"
       name: "custom log_rule for daemon event"
       pattern: name
       pattern_type: string
@@ -71,9 +69,8 @@ replaced:
   after:
     - alert_enabled: true
       alert_minimum_severity: 5
-      dependency: none
-      description: false
-      destination_iptype: "Replaced log daemon event"
+      dependency: "none"
+      description: "Replaced log daemon event"
       groups:
         - "test"
       level: 0
@@ -81,12 +78,12 @@ replaced:
         log_files:
           - format: syslog
             location: /var/log/messages
-      minimum_agent_version: 6.0.0.0
-      minimum_manager_version: 6.0.0
+      minimum_agent_version: "6.0.0.0"
+      minimum_manager_version: "6.0.0"
       name: "custom log_rule for daemon event"
       pattern: name
       pattern_type: string
       rule_description: "daemon rule description"
-      rule_id: 100002
+      rule_id: 100003
       sort_order: 15000
       template: basic-rule


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
To fix Deepsec log inspection rule idempotent bug where `dict` wasn’t converted back to `list` as expected and was resulting into unexpected output
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
deepsec_ log_inspection_rules

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below
{
    "log_files": {
        "log_files": {
            "syslog/var/log/messages": {
                "format": "syslog",
                "location": "/var/log/messages"
            }
        }
    }
}
```
`"syslog/var/log/messages"` shouldn’t be part of the `log_files` value
