### PR TITLE
Replace ansible.module_utils.six with Python stdlib equivalents

### DIFF
--- a/changelogs/fragments/remove-module-utils-six.yml
+++ b/changelogs/fragments/remove-module-utils-six.yml
@@ -1,0 +1,5 @@
+---
+minor_changes:
+  - Replace the deprecated ``ansible.module_utils.six`` compatibility shims with
+    their Python standard library equivalents. ``ansible.module_utils.six`` is
+    deprecated in ansible-core 2.21 and is scheduled for removal in 2.24.

--- a/plugins/action/deepsec_log_inspection_rules.py
+++ b/plugins/action/deepsec_log_inspection_rules.py
@@ -13,7 +13,6 @@ __metaclass__ = type
 
 from ansible.errors import AnsibleActionFail
 from ansible.module_utils.connection import Connection
-from ansible.module_utils.six import iteritems
 from ansible.plugins.action import ActionBase
 from ansible_collections.ansible.netcommon.plugins.module_utils.network.common import utils
 from ansible_collections.ansible.utils.plugins.module_utils.common.argspec_validate import (
@@ -88,7 +87,7 @@ class ActionModule(ActionBase):
     def convert_dict_to_list(self, params, key, sub_key):
         if isinstance(params[key][sub_key], dict):
             temp = []
-            for k, v in iteritems(params[key][sub_key]):
+            for k, v in params[key][sub_key].items():
                 temp.append(v)
             params[key][sub_key] = temp
         return params

--- a/plugins/httpapi/deepsec.py
+++ b/plugins/httpapi/deepsec.py
@@ -18,10 +18,11 @@ version_added: 1.0.0
 
 import json
 
+from urllib.error import HTTPError
+from urllib.parse import urlencode
+
 from ansible.errors import AnsibleAuthenticationFailure
 from ansible.module_utils.basic import to_bytes, to_text
-from ansible.module_utils.six.moves.urllib.error import HTTPError
-from ansible.module_utils.six.moves.urllib.parse import urlencode
 from ansible_collections.ansible.netcommon.plugins.plugin_utils.httpapi_base import HttpApiBase
 
 

--- a/plugins/module_utils/deepsec.py
+++ b/plugins/module_utils/deepsec.py
@@ -15,7 +15,6 @@ except ImportError:
 
 from ansible.module_utils._text import to_text
 from ansible.module_utils.connection import Connection, ConnectionError
-from ansible.module_utils.six import iteritems
 
 
 BASE_HEADERS = {
@@ -57,7 +56,7 @@ def map_params_to_obj(module_params, key_transform):
     :returns: dict with module prams transformed having API expected params
     """
     obj = {}
-    for k, v in iteritems(key_transform):
+    for k, v in key_transform.items():
         if k in module_params and (
             module_params.get(k) or module_params.get(k) == 0 or module_params.get(k) is False
         ):
@@ -79,14 +78,14 @@ def map_obj_to_params(module_return_params, key_transform, return_param):
         temp[return_param] = []
         for each in module_return_params[return_param]:
             api_temp = {}
-            for k, v in iteritems(key_transform):
+            for k, v in key_transform.items():
                 if v in each and (each.get(v) or each.get(v) == 0 or each.get(v) is False):
                     api_temp[k] = each.pop(v)
             if each:
                 api_temp.update(each)
             temp[return_param].append(api_temp)
     else:
-        for k, v in iteritems(key_transform):
+        for k, v in key_transform.items():
             if v in module_return_params and (
                 module_return_params.get(v)
                 or module_return_params.get(v) == 0

--- a/plugins/modules/deepsec_anti_malware.py
+++ b/plugins/modules/deepsec_anti_malware.py
@@ -219,7 +219,6 @@ EXAMPLES = """
 """
 
 from ansible.module_utils.basic import AnsibleModule
-from ansible.module_utils.six import iteritems
 from ansible_collections.ansible.netcommon.plugins.module_utils.network.common.utils import (
     remove_empties,
 )
@@ -278,7 +277,7 @@ def map_params_to_obj(module_params):
     obj["name"] = module_params["name"]
     if module_params.get("description"):
         obj["description"] = module_params.get("description")
-    for k, v in iteritems(key_transform):
+    for k, v in key_transform.items():
         if module_params.get(k):
             obj[v] = module_params.get(k)
     return obj

--- a/plugins/modules/deepsec_firewallrules.py
+++ b/plugins/modules/deepsec_firewallrules.py
@@ -292,7 +292,6 @@ EXAMPLES = """
 """
 
 from ansible.module_utils.basic import AnsibleModule
-from ansible.module_utils.six import iteritems
 from ansible_collections.ansible.netcommon.plugins.module_utils.network.common.utils import (
     remove_empties,
 )
@@ -374,7 +373,7 @@ def map_params_to_obj(module_params):
         obj["protocol"] = module_params.get("protocol")
     if module_params.get("tcpflags"):
         obj["tcpflags"] = module_params.get("tcpflags")
-    for k, v in iteritems(key_transform):
+    for k, v in key_transform.items():
         if module_params.get(k):
             obj[v] = module_params.get(k)
     return obj

--- a/plugins/modules/deepsec_log_inspectionrules.py
+++ b/plugins/modules/deepsec_log_inspectionrules.py
@@ -249,7 +249,6 @@ EXAMPLES = """
 """
 
 from ansible.module_utils.basic import AnsibleModule
-from ansible.module_utils.six import iteritems
 from ansible_collections.ansible.netcommon.plugins.module_utils.network.common.utils import (
     remove_empties,
 )
@@ -312,7 +311,7 @@ def map_params_to_obj(module_params):
         obj["frequency"] = module_params.get("frequency")
     if module_params.get("log_files"):
         obj["logFiles"] = log_files_fn(module_params)
-    for k, v in iteritems(key_transform):
+    for k, v in key_transform.items():
         if module_params.get(k):
             obj[v] = module_params.get(k)
 

--- a/plugins/modules/deepsec_syslog.py
+++ b/plugins/modules/deepsec_syslog.py
@@ -147,7 +147,6 @@ EXAMPLES = """
 """
 
 from ansible.module_utils.basic import AnsibleModule
-from ansible.module_utils.six import iteritems
 from ansible_collections.ansible.netcommon.plugins.module_utils.network.common.utils import (
     remove_empties,
 )
@@ -179,7 +178,7 @@ def check_if_syslog_config_exists(
             }
             for each in syslog_response["ListSyslogConfigurationsResponse"]["syslogConfigurations"]:
                 sorted(each)
-                for k, v in iteritems(key_transform):
+                for k, v in key_transform.items():
                     if k in each:
                         each[v] = each[k]
                         each.pop(k)

--- a/plugins/modules/deepsec_system_settings.py
+++ b/plugins/modules/deepsec_system_settings.py
@@ -1811,7 +1811,6 @@ EXAMPLES = """
 """
 
 from ansible.module_utils.basic import AnsibleModule
-from ansible.module_utils.six import iteritems
 from ansible_collections.ansible.netcommon.plugins.module_utils.network.common import utils
 
 from ansible_collections.trendmicro.deepsec.plugins.module_utils.deepsec import (
@@ -2120,7 +2119,7 @@ def configure_module_api(argspec, module, deepsec_request):
         changed = False
         search_result = search_for_system_settings_default(deepsec_request)
         temp_config = {}
-        for k, v in iteritems(module.params["config"]):
+        for k, v in module.params["config"].items():
             system_setting_name = key_transform[k]
             before.update({k: search_result[system_setting_name]})
             if (
@@ -2136,7 +2135,7 @@ def configure_module_api(argspec, module, deepsec_request):
                     temp_config.update({system_setting_name: v})
                 after.update({k: v})
         if len(temp_config) == 1:
-            for k, v in iteritems(temp_config):
+            for k, v in temp_config.items():
                 api_key = deepsec_request.post("{0}/{1}".format(api_object, k), data=v)
                 if api_key.get("errors"):
                     module.fail_json(msg=api_key["errors"])

--- a/tests/unit/plugins/modules/conftest.py
+++ b/tests/unit/plugins/modules/conftest.py
@@ -11,12 +11,11 @@ import pytest
 
 from ansible.module_utils._text import to_bytes
 from ansible.module_utils.common._collections_compat import MutableMapping
-from ansible.module_utils.six import string_types
 
 
 @pytest.fixture
 def patch_ansible_module(request, mocker):
-    if isinstance(request.param, string_types):
+    if isinstance(request.param, str):
         args = request.param
     elif isinstance(request.param, MutableMapping):
         if "ANSIBLE_MODULE_ARGS" not in request.param:


### PR DESCRIPTION
##### SUMMARY

`ansible.module_utils.six` is deprecated in ansible-core 2.21 and scheduled for removal in 2.24. This removes it from all plugin code:

| six | stdlib |
| --- | --- |
| `six.moves.urllib.parse urlencode` | `urllib.parse` |
| `six.moves.urllib.error HTTPError` | `urllib.error` |
| `iteritems(d)` | `d.items()` |
| `string_types` | `str` |

All identity mappings on Python 3. The `iteritems(key_transform)` loops in `module_utils/deepsec.py` and the modules iterate the transform map while writing to a separate dict, so switching from an iterator to a view changes nothing. Note the local variable named `text_type` in `find_dict_in_list()` is unrelated to six and is untouched. Imports are placed in the stdlib group so the pinned isort/black pre-commit hooks stay clean. A changelog fragment is included.

Not covered, deliberately: `tests/unit/mock/procenv.py` and `tests/unit/mock/yaml_helper.py` still import `PY3`. Those are vendored copies of ansible-core test helpers that nothing in this repo imports. They looked better deleted than patched, which felt out of scope here. Happy to handle them in this PR if you prefer.

##### ISSUE TYPE

- Refactoring Pull Request

##### COMPONENT NAME

deepsec httpapi/action/module_utils plugins, deepsec_anti_malware, deepsec_firewallrules, deepsec_log_inspectionrules, deepsec_syslog, deepsec_system_settings
